### PR TITLE
feat: Exclusive wallet level delegations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ docs/
 
 # Dotenv file
 .env
+
+# zksolc
+zkout/


### PR DESCRIPTION
Adds the ability to resolve an exclusive wallet level delegation - this is useful for resolving things like allowlists etc, where the criteria may not be associated with ownership of a specific NFT.

Also adds a reverse lookup for getting all exclusive wallet level delegations to a specific wallet.